### PR TITLE
Add reclassify raster to plugin

### DIFF
--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -45,7 +45,7 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -2,6 +2,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -23,6 +24,7 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "interval_size",
+            "bands",
             "output_raster",
         ]
 
@@ -38,8 +40,16 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         interval_size_param.setHelp("The interval size for Defined intervals.")
         self.addParameter(interval_size_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -1,0 +1,45 @@
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_defined_intervals"
+        self._display_name = "Reclassify with defined intervals"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with defined intervals."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "interval_size",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        interval_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2], description="Interval size"
+        )
+        interval_size_param.setHelp("The interval size for Defined intervals.")
+        self.addParameter(interval_size_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[6], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -44,7 +44,7 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -40,7 +40,7 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         interval_size_param.setHelp("The interval size for Defined intervals.")
         self.addParameter(interval_size_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -1,8 +1,8 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -35,7 +35,9 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         self.addParameter(input_raster_param)
 
         interval_size_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[1], description="Interval size"
+            name=self.alg_parameters[1],
+            description="Interval size",
+            minValue=1,
         )
         interval_size_param.setHelp("The interval size for Defined intervals.")
         self.addParameter(interval_size_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -33,13 +33,13 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         self.addParameter(input_raster_param)
 
         interval_size_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[2], description="Interval size"
+            name=self.alg_parameters[1], description="Interval size"
         )
         interval_size_param.setHelp("The interval size for Defined intervals.")
         self.addParameter(interval_size_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[6], description="Output raster"
+            name=self.alg_parameters[2], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_defined_intervals.py
@@ -44,10 +44,10 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -1,10 +1,9 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
-
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
@@ -40,7 +39,7 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
         interval_size_param.setHelp("The number of intervals for Equal intervals.")
         self.addParameter(interval_size_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -4,6 +4,7 @@ from qgis.core import (
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
+
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -2,6 +2,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -23,6 +24,7 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "number_of_intervals",
+            "bands",
             "output_raster",
         ]
 
@@ -38,8 +40,16 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
         interval_size_param.setHelp("The number of intervals for Equal intervals.")
         self.addParameter(interval_size_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -45,7 +45,7 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -1,0 +1,45 @@
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_equal_intervals"
+        self._display_name = "Reclassify with equal intervals"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with equal intervals."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "number_of_intervals",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        interval_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2], description="Number of intervals"
+        )
+        interval_size_param.setHelp("The number of intervals for Equal intervals.")
+        self.addParameter(interval_size_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[6], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -7,7 +7,7 @@ from qgis.core import (
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
-class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
+class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
     def __init__(self) -> None:
         super().__init__()
 

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -33,13 +33,13 @@ class EISReclassifyWithDefinedIntervals(EISProcessingAlgorithm):
         self.addParameter(input_raster_param)
 
         interval_size_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[2], description="Number of intervals"
+            name=self.alg_parameters[1], description="Number of intervals"
         )
         interval_size_param.setHelp("The number of intervals for Equal intervals.")
         self.addParameter(interval_size_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[6], description="Output raster"
+            name=self.alg_parameters[2], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -44,10 +44,10 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -34,7 +34,9 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
         self.addParameter(input_raster_param)
 
         interval_size_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[1], description="Number of intervals"
+            name=self.alg_parameters[1],
+            description="Number of intervals",
+            minValue=2,
         )
         interval_size_param.setHelp("The number of intervals for Equal intervals.")
         self.addParameter(interval_size_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_equal_intervals.py
@@ -43,7 +43,7 @@ class EISReclassifyWithEqualIntervals(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -45,7 +45,7 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -36,7 +36,8 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
 
         breaks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="The number of classes"
+            description="The number of classes",
+            minValue=2,
         )
         breaks_param.setHelp("The number of classes for Geometrical intervals.")
         self.addParameter(breaks_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -1,0 +1,46 @@
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_geometrical_intervals"
+        self._display_name = "Reclassify with geometrical intervals"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with geometrical intervals."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "number_of_classes",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        breaks_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="The number of classes"
+        )
+        breaks_param.setHelp("The number of classes for Geometrical intervals.")
+        self.addParameter(breaks_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[2], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -1,8 +1,8 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -41,7 +41,7 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
         breaks_param.setHelp("The number of classes for Geometrical intervals.")
         self.addParameter(breaks_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -2,6 +2,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -23,6 +24,7 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "number_of_classes",
+            "bands",
             "output_raster",
         ]
 
@@ -39,8 +41,16 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
         breaks_param.setHelp("The number of classes for Geometrical intervals.")
         self.addParameter(breaks_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -44,7 +44,7 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_geometrical_intervals.py
@@ -44,10 +44,10 @@ class EISReclassifyWithGeometricalIntervals(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
@@ -46,7 +46,7 @@ class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
@@ -23,6 +23,7 @@ class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "breaks",
+            "bands",
             "output_raster",
         ]
 
@@ -42,8 +43,16 @@ class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
         )
         self.addParameter(breaks_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
@@ -1,0 +1,49 @@
+from qgis.core import (
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_manual_breaks"
+        self._display_name = "Reclassify with manual breaks"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with manual breaks."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "breaks",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        breaks_param = QgsProcessingParameterString(
+            name=self.alg_parameters[1],
+            description="Breaks"
+        )
+        breaks_param.setHelp(
+            '''The breaks for Manual breaks. Input the breaks as a comma-separated list. 
+            For example: 0, 10, 20, 30, 40, 50.'''
+        )
+        self.addParameter(breaks_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[2], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
@@ -1,4 +1,5 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
     QgsProcessingParameterString,
@@ -43,7 +44,7 @@ class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
         )
         self.addParameter(breaks_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
@@ -47,7 +47,7 @@ class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_manual_breaks.py
@@ -53,10 +53,10 @@ class EISReclassifyWithManualBreaks(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -2,6 +2,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -23,6 +24,7 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "number_of_classes",
+            "bands",
             "output_raster",
         ]
 
@@ -39,8 +41,16 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
         breaks_param.setHelp("The number of classes for Natural breaks.")
         self.addParameter(breaks_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -4,6 +4,7 @@ from qgis.core import (
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
+
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -1,7 +1,7 @@
 from qgis.core import (
+    QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -32,7 +32,7 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
         input_raster_param.setHelp("The input raster data set.")
         self.addParameter(input_raster_param)
 
-        breaks_param = QgsProcessingParameterString(
+        breaks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="The number of classes"
         )

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -35,7 +35,8 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
 
         breaks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="The number of classes"
+            description="The number of classes",
+            minValue=2,
         )
         breaks_param.setHelp("The number of classes for Natural breaks.")
         self.addParameter(breaks_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -1,10 +1,9 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
-
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
@@ -41,7 +40,7 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
         breaks_param.setHelp("The number of classes for Natural breaks.")
         self.addParameter(breaks_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -45,7 +45,7 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -1,0 +1,46 @@
+from qgis.core import (
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_natural_breaks"
+        self._display_name = "Reclassify with natural breaks"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with natural breaks."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "number_of_classes",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        breaks_param = QgsProcessingParameterString(
+            name=self.alg_parameters[1],
+            description="The number of classes"
+        )
+        breaks_param.setHelp("The number of classes for Natural breaks.")
+        self.addParameter(breaks_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[2], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -44,10 +44,10 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_natural_breaks.py
@@ -43,7 +43,7 @@ class EISReclassifyWithNaturalBreaks(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -44,10 +44,10 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -23,7 +23,7 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
     def initAlgorithm(self, config=None):
         self.alg_parameters = [
             "input_raster",
-            "quantiles",
+            "number_of_quantiles",
             "bands",
             "output_raster",
         ]

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -2,6 +2,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -23,6 +24,7 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "quantiles",
+            "bands",
             "output_raster",
         ]
 
@@ -39,8 +41,16 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
         quantiles_param.setHelp("The Quantiles for reclassification.")
         self.addParameter(quantiles_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -1,0 +1,46 @@
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_quantiles"
+        self._display_name = "Reclassify with quantiles"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with quantiles."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "quantiles",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        quantiles_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Quantiles"
+        )
+        quantiles_param.setHelp("The Quantiles for reclassification.")
+        self.addParameter(quantiles_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[2], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -36,7 +36,8 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
 
         quantiles_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="Quantiles"
+            description="Quantiles",
+            minValue=2,
         )
         quantiles_param.setHelp("The Quantiles for reclassification.")
         self.addParameter(quantiles_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -44,7 +44,7 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -45,7 +45,7 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_quantiles.py
@@ -1,8 +1,8 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -41,7 +41,7 @@ class EISReclassifyWithQuantiles(EISProcessingAlgorithm):
         quantiles_param.setHelp("The Quantiles for reclassification.")
         self.addParameter(quantiles_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -2,6 +2,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -23,6 +24,7 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
         self.alg_parameters = [
             "input_raster",
             "number_of_intervals",
+            "bands",
             "output_raster",
         ]
 
@@ -38,8 +40,16 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
         interval_size_param.setHelp("The number of standard deviation.")
         self.addParameter(interval_size_param)
 
+        bands_param = QgsProcessingParameterString(
+            name=self.alg_parameters[2],
+            description="Bands",
+            optional=True,
+        )
+        bands_param.setHelp("The bands to be reclassified.")
+        self.addParameter(bands_param)
+
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[2], description="Output raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -45,7 +45,7 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Raster bands",
-            optional=True,
+            parentLayerParameterName=self.alg_parameters[0],
         )
         bands_param.setHelp("The bands to be reclassified.")
         self.addParameter(bands_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -35,7 +35,9 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
         self.addParameter(input_raster_param)
 
         interval_size_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[1], description="Number of standard deviations"
+            name=self.alg_parameters[1],
+            description="Number of standard deviations",
+            minValue=2,
         )
         interval_size_param.setHelp("The number of standard deviation.")
         self.addParameter(interval_size_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -44,7 +44,7 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Bands",
+            description="Raster bands",
             optional=True,
         )
         bands_param.setHelp("The bands to be reclassified.")

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -1,8 +1,8 @@
 from qgis.core import (
+    QgsProcessingParameterBand,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
-    QgsProcessingParameterString,
 )
 
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
@@ -40,7 +40,7 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
         interval_size_param.setHelp("The number of standard deviation.")
         self.addParameter(interval_size_param)
 
-        bands_param = QgsProcessingParameterString(
+        bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
             description="Bands",
             optional=True,

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -1,0 +1,45 @@
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "reclassify_with_standard_deviation"
+        self._display_name = "Reclassify with standard deviation"
+        self._group = "Raster Processing"
+        self._group_id = "raster_processing"
+        self._short_help_string = (
+            "Reclassify raster data set with standard deviation."
+        )
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "number_of_intervals",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+        )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        interval_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1], description="Number of standard deviations"
+        )
+        interval_size_param.setHelp("The number of standard deviation.")
+        self.addParameter(interval_size_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[2], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
+++ b/eis_qgis_plugin/processing/algorithms/raster_processing/reclassify_with_standard_deviation.py
@@ -44,10 +44,10 @@ class EISReclassifyWithStandardDeviation(EISProcessingAlgorithm):
 
         bands_param = QgsProcessingParameterBand(
             name=self.alg_parameters[2],
-            description="Raster bands",
+            description="Raster band",
             parentLayerParameterName=self.alg_parameters[0],
         )
-        bands_param.setHelp("The bands to be reclassified.")
+        bands_param.setHelp("The band to be reclassified.")
         self.addParameter(bands_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(

--- a/eis_qgis_plugin/processing/eis_processing_algorithm.py
+++ b/eis_qgis_plugin/processing/eis_processing_algorithm.py
@@ -6,6 +6,7 @@ from qgis.core import (
     QgsProcessingContext,
     QgsProcessingFeedback,
     QgsProcessingOutputMultipleLayers,
+    QgsProcessingParameterBand,
     QgsProcessingParameterBoolean,
     QgsProcessingParameterCrs,
     QgsProcessingParameterDefinition,
@@ -132,7 +133,11 @@ class EISProcessingAlgorithm(QgsProcessingAlgorithm):
         for name in self.alg_parameters:
             param = self.parameterDefinition(name)
             param_name = "--" + name.replace("_", "-")
-            if isinstance(param, QgsProcessingParameterBoolean):
+
+            if isinstance(param, QgsProcessingParameterBand):
+                param_value = str(self.parameterAsInt(parameters, name, context))
+
+            elif isinstance(param, QgsProcessingParameterBoolean):
                 if self.parameterAsBool(parameters, name, context):
                     typer_options.append(param_name)
                 else:


### PR DESCRIPTION
This PR adds the following Reclassify raster functions to the plugin:

- Defined intervals
- Equal intervals
- Geometrical intervals
- Manual breaks
- Natural breaks
- Quantiles
- Standard deviation

The setHelp function is used to describe what the tools are for and Manual breaks contain an example input to the challenging `breaks` field.