### PR TITLE
Add filter/smoothing algorithms to plugin

### DIFF
--- a/eis_qgis_plugin/processing/algorithms/filtering/focal_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/focal_filter.py
@@ -1,0 +1,73 @@
+from qgis.core import (
+    QgsProcessingParameterEnum,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISFocalFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "focal_filter"
+        self._display_name = "Focal filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = "Apply a basic focal filter to the input raster"
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "method",
+            "size",
+            "shape",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+       
+        method_param = QgsProcessingParameterEnum(
+            name=self.alg_parameters[1],
+            description="Method",
+            options=["mean", "median"],
+            defaultValue="mean",
+        )
+        method_param.setHelp(
+            "The method to use for filtering. Can be either 'mean' or 'median'. Default to 'mean'."
+        )
+        self.addParameter(method_param)
+
+        size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Size",
+            minValue=1,
+            defaultValue=3,
+        )
+        size_param.setHelp(
+            "The size of the filter window. E.g., 3 means a 3x3 window. Default to 3."
+        )
+        self.addParameter(size_param)
+           
+        shape_param = QgsProcessingParameterEnum(
+            name=self.alg_parameters[3],
+            description="Shape",
+            options=["circle", "square"],
+            defaultValue="circle",
+        )
+        shape_param.setHelp(
+            "The shape of the filter window. Can be either 'square' or 'circle'. Default to 'circle'."
+        )
+        self.addParameter(shape_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[4], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/focal_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/focal_filter.py
@@ -44,16 +44,20 @@ class EISFocalFilter(EISProcessingAlgorithm):
         )
         self.addParameter(method_param)
 
-        size_param = QgsProcessingParameterNumber(
+        window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
-        size_param.setHelp(
-            "The size of the filter window. E.g., 3 means a 3x3 window."
+        window_size_param.setHelp(
+            '''
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
+            '''
         )
-        self.addParameter(size_param)
+        self.addParameter(window_size_param)
            
         shape_param = QgsProcessingParameterEnum(
             name=self.alg_parameters[3],

--- a/eis_qgis_plugin/processing/algorithms/filtering/focal_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/focal_filter.py
@@ -40,7 +40,7 @@ class EISFocalFilter(EISProcessingAlgorithm):
             defaultValue="mean",
         )
         method_param.setHelp(
-            "The method to use for filtering. Can be either 'mean' or 'median'. Default to 'mean'."
+            "The method to use for filtering. Can be either 'mean' or 'median'."
         )
         self.addParameter(method_param)
 
@@ -51,7 +51,7 @@ class EISFocalFilter(EISProcessingAlgorithm):
             defaultValue=3,
         )
         size_param.setHelp(
-            "The size of the filter window. E.g., 3 means a 3x3 window. Default to 3."
+            "The size of the filter window. E.g., 3 means a 3x3 window."
         )
         self.addParameter(size_param)
            
@@ -62,7 +62,7 @@ class EISFocalFilter(EISProcessingAlgorithm):
             defaultValue="circle",
         )
         shape_param.setHelp(
-            "The shape of the filter window. Can be either 'square' or 'circle'. Default to 'circle'."
+            "The shape of the filter window. Can be either 'square' or 'circle'."
         )
         self.addParameter(shape_param)
 

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -1,0 +1,73 @@
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+
+
+class EISFrostFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "frost_filter"
+        self._display_name = "Frost Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = '''
+            Apply a Frost filter to the input raster.
+            Higher number of looks result in better edge preservation.
+            '''
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "size",
+            "damping_factor",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        window_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Size",
+            minValue=1,
+            defaultValue=3,
+        )
+        window_size_param.setHelp(
+            '''
+            The size of the filter window.
+            E.g., 3 means a 3x3 window. Default to 3.
+            '''
+        )
+        self.addParameter(window_size_param)
+
+        damping_factor = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Extent of exponential damping effect on filtering.",
+            minValue=0.1,
+            defaultValue=1.0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        damping_factor.setHelp(
+            '''
+            Extent of exponential damping effect on filtering.
+            Larger damping values preserve edges better but smooths less.
+            Smaller values produce more smoothing.
+            Default to 1.
+            '''
+        )
+        self.addParameter(damping_factor)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[3], description="Output Raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -51,7 +51,7 @@ class EISFrostFilter(EISProcessingAlgorithm):
 
         damping_factor = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Extent of exponential damping effect on filtering.",
+            description="Damping factor",
             minValue=0.1,
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -42,8 +42,9 @@ class EISFrostFilter(EISProcessingAlgorithm):
         )
         window_size_param.setHelp(
             '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window.
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -1,11 +1,10 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
 
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
 class EISFrostFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -51,7 +51,7 @@ class EISFrostFilter(EISProcessingAlgorithm):
         damping_factor = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Damping factor",
-            minValue=0.001,
+            minValue=0,
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -51,7 +51,7 @@ class EISFrostFilter(EISProcessingAlgorithm):
         damping_factor = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Damping factor",
-            minValue=0.1,
+            minValue=0.001,
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -37,7 +37,7 @@ class EISFrostFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -12,7 +12,7 @@ class EISFrostFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "frost_filter"
-        self._display_name = "Frost Filter"
+        self._display_name = "Frost filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = '''

--- a/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/frost_filter.py
@@ -43,7 +43,7 @@ class EISFrostFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
@@ -60,13 +60,12 @@ class EISFrostFilter(EISProcessingAlgorithm):
             Extent of exponential damping effect on filtering.
             Larger damping values preserve edges better but smooths less.
             Smaller values produce more smoothing.
-            Default to 1.
             '''
         )
         self.addParameter(damping_factor)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[3], description="Output Raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -39,7 +39,7 @@ class EISGammaFilter(EISProcessingAlgorithm):
             name=self.alg_parameters[1],
             description="Size",
             minValue=0.1,
-            defaultValue=1,
+            defaultValue=3,
         )
         window_size_param.setHelp(
             '''

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -42,8 +42,9 @@ class EISGammaFilter(EISProcessingAlgorithm):
         )
         window_size_param.setHelp(
             '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window.
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -35,16 +35,11 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
 
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="Size",
-            minValue=1,
-            defaultValue=3,
+            description="Multiplicative Noise Variation",
+            minValue=0.1,
+            defaultValue=1,
         )
-        window_size_param.setHelp(
-            '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
-            '''
-        )
+        window_size_param.setHelp("The multiplicative noise variation. Default to 1.")
         self.addParameter(window_size_param)
 
         noise_var_param = QgsProcessingParameterNumber(

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -8,21 +8,23 @@ from qgis.core import (
 
 
 
-class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
+class EISGammaFilter(EISProcessingAlgorithm):
     def __init__(self) -> None:
         super().__init__()
 
-        self._name = "lee_multiplicative_noise_filter"
-        self._display_name = "Lee Multiplicative Noise Filter"
+        self._name = "gamma_filter"
+        self._display_name = "Gamma Filter"
         self._group = "Filtering"
         self._group_id = "filtering"
-        self._short_help_string = "Apply a Lee filter considering multiplicative noise components to the input raster"
+        self._short_help_string = '''
+            Apply a Gamma filter to the input raster.
+            Higher number of looks result in better edge preservation.
+            '''
 
     def initAlgorithm(self, config=None):
         self.alg_parameters = [
             "input_raster",
             "size",
-            "multi_noise_mean",
             "n_looks",
             "output_raster",
         ]
@@ -35,43 +37,36 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
 
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="Multiplicative Noise Variation",
+            description="Gamma Noise Variation",
             minValue=0.1,
             defaultValue=1,
         )
-        window_size_param.setHelp("The multiplicative noise variation. Default to 1.")
-        self.addParameter(window_size_param)
-
-        noise_var_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[2],
-            description="Multiplicative Noise Variation",
-            minValue=1,
-            defaultValue=3,
-        )
-        noise_var_param.setHelp(
+        window_size_param.setHelp(
             '''
             The size of the filter window.
             E.g., 3 means a 3x3 window. Default to 3.
             '''
         )
-        self.addParameter(noise_var_param)
+        self.addParameter(window_size_param)
 
         n_looks_param = QgsProcessingParameterNumber(
-            name=self.alg_parameters[3],
-            description="Multiplicative Noise Variation",
+            name=self.alg_parameters[2],
+            description="Gamma Noise Variation",
             minValue=1,
             defaultValue=1,
         )
         n_looks_param.setHelp(
             '''
             Number of looks to estimate the noise variation.
-            Higher values result in higher smoothing. Default to 1.
+            Higher values result in higher smoothing.
+            Low values may result in focal mean filtering.
+            Default to 1.
             '''
         )
         self.addParameter(n_looks_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[4], description="Output Raster"
+            name=self.alg_parameters[3], description="Output Raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -37,7 +37,7 @@ class EISGammaFilter(EISProcessingAlgorithm):
 
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="Gamma Noise Variation",
+            description="Size",
             minValue=0.1,
             defaultValue=1,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -12,7 +12,7 @@ class EISGammaFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "gamma_filter"
-        self._display_name = "Gamma Filter"
+        self._display_name = "Gamma filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = '''

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -51,7 +51,7 @@ class EISGammaFilter(EISProcessingAlgorithm):
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Gamma Noise Variation",
+            description="Number of looks.",
             minValue=1,
             defaultValue=1,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -37,7 +37,7 @@ class EISGammaFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -1,11 +1,10 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
 
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
 class EISGammaFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -38,7 +38,7 @@ class EISGammaFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=0.1,
+            minValue=1,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gamma_filter.py
@@ -43,14 +43,14 @@ class EISGammaFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Number of looks.",
+            description="Number of looks",
             minValue=1,
             defaultValue=1,
         )
@@ -59,13 +59,12 @@ class EISGammaFilter(EISProcessingAlgorithm):
             Number of looks to estimate the noise variation.
             Higher values result in higher smoothing.
             Low values may result in focal mean filtering.
-            Default to 1.
             '''
         )
         self.addParameter(n_looks_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[3], description="Output Raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -1,5 +1,4 @@
 from qgis.core import (
-    QgsProcessingParameterEnum,
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -35,7 +35,7 @@ class EISGaussianFilter(EISProcessingAlgorithm):
         sigma_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Sigma",
-            minValue=1.0,
+            minValue=0.001,
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -52,7 +52,7 @@ class EISGaussianFilter(EISProcessingAlgorithm):
         truncate_param.setHelp(
             '''
             The truncation factor for the gaussian kernel based on the sigma value.
-            Only if size is not given. Default to 4.0.
+            Only if size is not given.
             E.g., for sigma = 1 and truncate = 4.0, the kernel size is 9x9.
             '''
         )
@@ -67,7 +67,6 @@ class EISGaussianFilter(EISProcessingAlgorithm):
             '''
             The size of the filter window. E.g., 3 means a 3x3 window.
             If size is not None, it overrides the dynamic size calculation based on sigma and truncate.
-            Default to None.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -61,6 +61,7 @@ class EISGaussianFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[3],
             description="Size",
+            minValue=3,
             optional=True,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -1,0 +1,80 @@
+from qgis.core import (
+    QgsProcessingParameterEnum,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISGaussianFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "gaussian_filter"
+        self._display_name = "Gaussian filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = "Apply a basic gaussian filter to the input raster"
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "sigma",
+            "truncate",
+            "size",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        sigma_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Sigma",
+            minValue=1.0,
+            defaultValue=1.0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        sigma_param.setHelp("The standard deviation of the gaussian kernel.")
+        self.addParameter(sigma_param)
+
+        truncate_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Truncate",
+            minValue=1.0,
+            defaultValue=4.0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        truncate_param.setHelp(
+            '''
+            The truncation factor for the gaussian kernel based on the sigma value.
+            Only if size is not given. Default to 4.0.
+            E.g., for sigma = 1 and truncate = 4.0, the kernel size is 9x9.
+            '''
+        )
+        self.addParameter(truncate_param)
+
+        size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[3],
+            description="Size",
+            optional=True,
+        )
+        size_param.setHelp(
+            '''
+            The size of the filter window. E.g., 3 means a 3x3 window.
+            If size is not None, it overrides the dynamic size calculation based on sigma and truncate.
+            Default to None.
+            '''
+        )
+        self.addParameter(size_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[4], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -45,7 +45,7 @@ class EISGaussianFilter(EISProcessingAlgorithm):
         truncate_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Truncate",
-            minValue=1.0,
+            minValue=0.001,
             defaultValue=4.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -68,6 +68,7 @@ class EISGaussianFilter(EISProcessingAlgorithm):
             '''
             The size of the filter window. E.g., 3 means a 3x3 window.
             If size is not None, it overrides the dynamic size calculation based on sigma and truncate.
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/gaussian_filter.py
@@ -58,19 +58,19 @@ class EISGaussianFilter(EISProcessingAlgorithm):
         )
         self.addParameter(truncate_param)
 
-        size_param = QgsProcessingParameterNumber(
+        window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[3],
             description="Size",
             optional=True,
         )
-        size_param.setHelp(
+        window_size_param.setHelp(
             '''
             The size of the filter window. E.g., 3 means a 3x3 window.
             If size is not None, it overrides the dynamic size calculation based on sigma and truncate.
             Default to None.
             '''
         )
-        self.addParameter(size_param)
+        self.addParameter(window_size_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
             name=self.alg_parameters[4], description="Output raster"

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -43,14 +43,14 @@ class EISKuanFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Number of looks.",
+            description="Number of looks",
             minValue=1,
             defaultValue=1,
         )
@@ -59,13 +59,12 @@ class EISKuanFilter(EISProcessingAlgorithm):
             Number of looks to estimate the noise variation.
             Higher values result in higher smoothing.
             Low values may result in focal mean filtering.
-            Default to 1.
             '''
         )
         self.addParameter(n_looks_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[3], description="Output Raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -1,0 +1,71 @@
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+
+class EISKuanFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "kuan_filter"
+        self._display_name = "Kuan Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = '''
+            Apply a Kuan filter to the input raster.
+            Higher number of looks result in better edge preservation.
+            '''
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "size",
+            "n_looks",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        window_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Size",
+            minValue=1,
+            defaultValue=3,
+        )
+        window_size_param.setHelp(
+            '''
+            The size of the filter window.
+            E.g., 3 means a 3x3 window. Default to 3.
+            '''
+        )
+        self.addParameter(window_size_param)
+
+        n_looks_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Number of looks to estimate the noise variation.",
+            minValue=1,
+            defaultValue=1,
+        )
+        n_looks_param.setHelp(
+            '''
+            Number of looks to estimate the noise variation.
+            Higher values result in higher smoothing.
+            Low values may result in focal mean filtering.
+            Default to 1.
+            '''
+        )
+        self.addParameter(n_looks_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[3], description="Output Raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -7,7 +7,6 @@ from qgis.core import (
 from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
-
 class EISKuanFilter(EISProcessingAlgorithm):
     def __init__(self) -> None:
         super().__init__()

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -1,10 +1,11 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
 
 
 class EISKuanFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -42,8 +42,9 @@ class EISKuanFilter(EISProcessingAlgorithm):
         )
         window_size_param.setHelp(
             '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window.
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -12,7 +12,7 @@ class EISKuanFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "kuan_filter"
-        self._display_name = "Kuan Filter"
+        self._display_name = "Kuan filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = '''

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -37,7 +37,7 @@ class EISKuanFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/kuan_filter.py
@@ -50,7 +50,7 @@ class EISKuanFilter(EISProcessingAlgorithm):
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Number of looks to estimate the noise variation.",
+            description="Number of looks.",
             minValue=1,
             defaultValue=1,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -39,7 +39,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Additive and Multiplicative Noise Variation",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -45,7 +45,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
@@ -57,7 +57,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             defaultValue=0.25,
             type=QgsProcessingParameterNumber.Double,
         )
-        add_noise_var_param.setHelp("The additive noise variation. Default to 0.25.")
+        add_noise_var_param.setHelp("The additive noise variation.")
         self.addParameter(add_noise_var_param)
 
         add_noise_mean_param = QgsProcessingParameterNumber(
@@ -66,7 +66,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             defaultValue=0,
             type=QgsProcessingParameterNumber.Double,
         )
-        add_noise_mean_param.setHelp("The additive noise mean. Default to 0.")
+        add_noise_mean_param.setHelp("The additive noise mean.")
         self.addParameter(add_noise_mean_param)
 
         mult_noise_mean_param = QgsProcessingParameterNumber(
@@ -76,11 +76,11 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,
         )
-        mult_noise_mean_param.setHelp("The multiplicative noise mean. Default to 1.")
+        mult_noise_mean_param.setHelp("The multiplicative noise mean.")
         self.addParameter(mult_noise_mean_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[5], description="Output Raster"
+            name=self.alg_parameters[5], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -12,12 +12,12 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "lee_additive_multiplicative_noise_filter"
-        self._display_name = "Lee Additive Multiplicative Noise Filter"
+        self._display_name = "Lee additive multiplicative noise filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = '''
             Apply a Lee filter considering additive 
-            and multiplicative noise components to the input raster"
+            and multiplicative noise components to the input raster
             '''
 
     def initAlgorithm(self, config=None):

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -38,7 +38,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
 
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
-            description="Additive and Multiplicative Noise Variation",
+            description="Size",
             minValue=3,
             defaultValue=3,
         )
@@ -46,6 +46,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             '''
             The size of the filter window.
             E.g., 3 means a 3x3 window.
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)
@@ -54,6 +55,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             name=self.alg_parameters[2],
             description="Additive Noise Variation",
             defaultValue=0.25,
+            minValue=0,
             type=QgsProcessingParameterNumber.Double,
         )
         add_noise_var_param.setHelp("The additive noise variation.")

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -63,6 +63,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             name=self.alg_parameters[3],
             description="Additive Noise Mean",
             defaultValue=0,
+            minValue=0,
             type=QgsProcessingParameterNumber.Double,
         )
         add_noise_mean_param.setHelp("The additive noise mean.")
@@ -72,6 +73,7 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             name=self.alg_parameters[4],
             description="Multiplicative Noise Mean",
             defaultValue=1.0,
+            minValue=0,
             type=QgsProcessingParameterNumber.Double,
         )
         mult_noise_mean_param.setHelp("The multiplicative noise mean.")

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -1,11 +1,10 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
 
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
 class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -53,7 +53,6 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         add_noise_var_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Additive Noise Variation",
-            minValue=0.1,
             defaultValue=0.25,
             type=QgsProcessingParameterNumber.Double,
         )
@@ -72,7 +71,6 @@ class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         mult_noise_mean_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[4],
             description="Multiplicative Noise Mean",
-            minValue=0.1,
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_multiplicative_noise_filter.py
@@ -1,0 +1,87 @@
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+
+
+class EISLeeAdditiveMultiplicativeNoiseFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "lee_additive_multiplicative_noise_filter"
+        self._display_name = "Lee Additive Multiplicative Noise Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = '''
+            Apply a Lee filter considering additive 
+            and multiplicative noise components to the input raster"
+            '''
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "size",
+            "add_noise_var",
+            "add_noise_mean",
+            "multi_noise_mean",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+            name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        window_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Additive and Multiplicative Noise Variation",
+            minValue=1,
+            defaultValue=3,
+        )
+        window_size_param.setHelp(
+            '''
+            The size of the filter window.
+            E.g., 3 means a 3x3 window. Default to 3.
+            '''
+        )
+        self.addParameter(window_size_param)
+
+        add_noise_var_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Additive Noise Variation",
+            minValue=0.1,
+            defaultValue=0.25,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        add_noise_var_param.setHelp("The additive noise variation. Default to 0.25.")
+        self.addParameter(add_noise_var_param)
+
+        add_noise_mean_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[3],
+            description="Additive Noise Mean",
+            defaultValue=0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        add_noise_mean_param.setHelp("The additive noise mean. Default to 0.")
+        self.addParameter(add_noise_mean_param)
+
+        mult_noise_mean_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[4],
+            description="Multiplicative Noise Mean",
+            minValue=0.1,
+            defaultValue=1.0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        mult_noise_mean_param.setHelp("The multiplicative noise mean. Default to 1.")
+        self.addParameter(mult_noise_mean_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[5], description="Output Raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -49,6 +49,7 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
             name=self.alg_parameters[2],
             description="Additive Noise Variation",
             defaultValue=0.25,
+            minValue=0,
             type=QgsProcessingParameterNumber.Double,
         )
         add_noise_var_param.setHelp("The additive noise variation.")

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -46,15 +46,15 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         )
         self.addParameter(window_size_param)
 
-        window_size_param = QgsProcessingParameterNumber(
+        add_noise_var_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Additive Noise Variation",
             minValue=0.1,
             defaultValue=0.25,
             type=QgsProcessingParameterNumber.Double,
         )
-        window_size_param.setHelp("The additive noise variation. Default to 0.25.")
-        self.addParameter(window_size_param)
+        add_noise_var_param.setHelp("The additive noise variation. Default to 0.25.")
+        self.addParameter(add_noise_var_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
             name=self.alg_parameters[3], description="Output Raster"

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -1,0 +1,63 @@
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+
+
+class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "lee_additive_noise_filter"
+        self._display_name = "Lee Additive Noise Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = "Apply a Lee filter considering additive noise components to the input raster"
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "size",
+            "add_noise_var",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        noise_var_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Size",
+            minValue=1,
+            defaultValue=3,
+        )
+        noise_var_param.setHelp(
+            '''
+            The size of the filter window.
+            E.g., 3 means a 3x3 window. Default to 3.
+            '''
+        )
+        self.addParameter(noise_var_param)
+
+        window_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Additive Noise Variation",
+            minValue=0.1,
+            defaultValue=0.25,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        window_size_param.setHelp("The additive noise variation. Default to 0.25.")
+        self.addParameter(window_size_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[3], description="Output Raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -40,7 +40,7 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
@@ -52,11 +52,11 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
             defaultValue=0.25,
             type=QgsProcessingParameterNumber.Double,
         )
-        add_noise_var_param.setHelp("The additive noise variation. Default to 0.25.")
+        add_noise_var_param.setHelp("The additive noise variation.")
         self.addParameter(add_noise_var_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[3], description="Output Raster"
+            name=self.alg_parameters[3], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -39,8 +39,9 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         )
         window_size_param.setHelp(
             '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window.
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -1,11 +1,10 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
 
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
 class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -32,19 +32,19 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         input_raster_param.setHelp("The input raster data set.")
         self.addParameter(input_raster_param)
 
-        noise_var_param = QgsProcessingParameterNumber(
+        window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
             minValue=1,
             defaultValue=3,
         )
-        noise_var_param.setHelp(
+        window_size_param.setHelp(
             '''
             The size of the filter window.
             E.g., 3 means a 3x3 window. Default to 3.
             '''
         )
-        self.addParameter(noise_var_param)
+        self.addParameter(window_size_param)
 
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -48,7 +48,6 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         add_noise_var_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Additive Noise Variation",
-            minValue=0.1,
             defaultValue=0.25,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -34,7 +34,7 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_additive_noise_filter.py
@@ -12,7 +12,7 @@ class EISLeeAdditiveNoiseFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "lee_additive_noise_filter"
-        self._display_name = "Lee Additive Noise Filter"
+        self._display_name = "Lee additive noise filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = "Apply a Lee filter considering additive noise components to the input raster"

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -1,0 +1,87 @@
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+
+
+class EISLeeEnhancedFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "lee_enhanced_filter"
+        self._display_name = "Lee Enhanced Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = "Apply a Lee filter considering multiplicative noise components to the input raster"
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "size",
+            "n_looks",
+            "damping_factor",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        window_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Size",
+            minValue=1,
+            defaultValue=3,
+        )
+        window_size_param.setHelp(
+            '''
+            The size of the filter window.
+            E.g., 3 means a 3x3 window. Default to 3.
+            '''
+        )
+        self.addParameter(window_size_param)
+
+        n_looks_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Multiplicative Noise Variation",
+            minValue=1,
+            defaultValue=1,
+        )
+        n_looks_param.setHelp(
+            '''
+            Number of looks to estimate the noise variation.
+            Higher values result in higher smoothing.
+            Low values may result in focal mean filtering.
+            Default to 1.
+            '''
+        )
+        self.addParameter(n_looks_param)
+
+        damping_factor = QgsProcessingParameterNumber(
+            name=self.alg_parameters[3],
+            description="Multiplicative Noise Variation",
+            minValue=0.1,
+            defaultValue=1,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        damping_factor.setHelp(
+            '''
+            Extent of exponential damping effect on filtering.
+            Larger damping values preserve edges better but smooths less.
+            Smaller values produce more smoothing.
+            Default to 1.
+            '''
+        )
+        self.addParameter(damping_factor)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[4], description="Output Raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -1,11 +1,10 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
 
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
 class EISLeeEnhancedFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -41,14 +41,14 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Number of looks.",
+            description="Number of looks",
             minValue=1,
             defaultValue=1,
         )
@@ -57,7 +57,6 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
             Number of looks to estimate the noise variation.
             Higher values result in higher smoothing.
             Low values may result in focal mean filtering.
-            Default to 1.
             '''
         )
         self.addParameter(n_looks_param)
@@ -74,13 +73,12 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
             Extent of exponential damping effect on filtering.
             Larger damping values preserve edges better but smooths less.
             Smaller values produce more smoothing.
-            Default to 1.
             '''
         )
         self.addParameter(damping_factor)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[4], description="Output Raster"
+            name=self.alg_parameters[4], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -35,7 +35,7 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -40,8 +40,9 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
         )
         window_size_param.setHelp(
             '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window.
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -12,7 +12,7 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "lee_enhanced_filter"
-        self._display_name = "Lee Enhanced Filter"
+        self._display_name = "Lee enhanced filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = "Apply a Lee filter considering multiplicative noise components to the input raster"

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -64,7 +64,7 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
         damping_factor = QgsProcessingParameterNumber(
             name=self.alg_parameters[3],
             description="Damping factor",
-            minValue=0.001,
+            minValue=0,
             defaultValue=1,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -49,7 +49,7 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
-            description="Multiplicative Noise Variation",
+            description="Number of looks.",
             minValue=1,
             defaultValue=1,
         )
@@ -65,7 +65,7 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
 
         damping_factor = QgsProcessingParameterNumber(
             name=self.alg_parameters[3],
-            description="Multiplicative Noise Variation",
+            description="Damping factor",
             minValue=0.1,
             defaultValue=1,
             type=QgsProcessingParameterNumber.Double,

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_enhanced_filter.py
@@ -64,7 +64,7 @@ class EISLeeEnhancedFilter(EISProcessingAlgorithm):
         damping_factor = QgsProcessingParameterNumber(
             name=self.alg_parameters[3],
             description="Damping factor",
-            minValue=0.1,
+            minValue=0.001,
             defaultValue=1,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -12,7 +12,7 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "lee_multiplicative_noise_filter"
-        self._display_name = "Lee Multiplicative Noise Filter"
+        self._display_name = "Lee multiplicative noise filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = "Apply a Lee filter considering multiplicative noise components to the input raster"

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -1,0 +1,77 @@
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+from qgis.core import (
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+
+
+class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "lee_multiplicative_noise_filter"
+        self._display_name = "Lee Multiplicative Noise Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = "Apply a Lee filter considering multiplicative noise components to the input raster"
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "size",
+            "multi_noise_mean",
+            "n_looks",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        noise_var_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Multiplicative Noise Variation",
+            minValue=1,
+            defaultValue=3,
+        )
+        noise_var_param.setHelp(
+            '''
+            The size of the filter window.
+            E.g., 3 means a 3x3 window. Default to 3.
+            '''
+        )
+        self.addParameter(noise_var_param)
+
+        window_size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Multiplicative Noise Variation",
+            minValue=0.1,
+            defaultValue=1,
+        )
+        window_size_param.setHelp("The multiplicative noise variation. Default to 1.")
+        self.addParameter(window_size_param)
+
+        n_looks_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[3],
+            description="Multiplicative Noise Variation",
+            minValue=1,
+            defaultValue=1,
+        )
+        n_looks_param.setHelp(
+            '''
+            Number of looks to estimate the noise variation.
+            Higher values result in higher smoothing. Default to 1.
+            '''
+        )
+        self.addParameter(n_looks_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[4], description="Output Raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -1,11 +1,10 @@
-from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
-
 from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterRasterDestination,
     QgsProcessingParameterRasterLayer,
 )
 
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
 
 
 class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -41,7 +41,7 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         window_size_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(window_size_param)
@@ -55,7 +55,7 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         noise_var_param.setHelp(
             '''
             The size of the filter window.
-            E.g., 3 means a 3x3 window. Default to 3.
+            E.g., 3 means a 3x3 window.
             '''
         )
         self.addParameter(noise_var_param)
@@ -71,13 +71,12 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
             Number of looks to estimate the noise variation.
             Higher values result in higher smoothing.
             Low values may result in focal mean filtering.
-            Default to 1.
             '''
         )
         self.addParameter(n_looks_param)
 
         output_raster_param = QgsProcessingParameterRasterDestination(
-            name=self.alg_parameters[4], description="Output Raster"
+            name=self.alg_parameters[4], description="Output raster"
         )
         output_raster_param.setHelp("The output raster data set.")
         self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -40,8 +40,9 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         )
         window_size_param.setHelp(
             '''
-            The size of the filter window.
-            E.g., 3 means a 3x3 window.
+            The size of the filter window. 
+            E.g., 3 means a 3x3 window. 
+            Only odd numbers are allowed.
             '''
         )
         self.addParameter(window_size_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -49,7 +49,7 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         noise_var_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Multiplicative Noise Variation",
-            minValue=1,
+            minValue=0,
             defaultValue=3,
         )
         noise_var_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -63,14 +63,16 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
 
         n_looks_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[3],
-            description="Multiplicative Noise Variation",
+            description="Number of looks",
             minValue=1,
             defaultValue=1,
         )
         n_looks_param.setHelp(
             '''
             Number of looks to estimate the noise variation.
-            Higher values result in higher smoothing. Default to 1.
+            Higher values result in higher smoothing.
+            Low values may result in focal mean filtering.
+            Default to 1.
             '''
         )
         self.addParameter(n_looks_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/lee_multiplicative_noise_filter.py
@@ -35,7 +35,7 @@ class EISLeeMultiplicativeNoiseFilter(EISProcessingAlgorithm):
         window_size_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Size",
-            minValue=1,
+            minValue=3,
             defaultValue=3,
         )
         window_size_param.setHelp(

--- a/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
@@ -47,7 +47,7 @@ class EISMexicanHatFilter(EISProcessingAlgorithm):
         truncate_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[2],
             description="Truncate",
-            minValue=1.0,
+            minValue=0.001,
             defaultValue=4.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
@@ -13,7 +13,7 @@ class EISMexicanHatFilter(EISProcessingAlgorithm):
         super().__init__()
 
         self._name = "mexican_hat_filter"
-        self._display_name = "Mexican Hat Filter"
+        self._display_name = "Mexican hat filter"
         self._group = "Filtering"
         self._group_id = "filtering"
         self._short_help_string = "Apply a Mexican hat filter to the input raster"

--- a/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
@@ -54,7 +54,7 @@ class EISMexicanHatFilter(EISProcessingAlgorithm):
         truncate_param.setHelp(
             '''
             The truncation factor for the gaussian kernel based on the sigma value.
-            Only if size is not given. Default to 4.0.
+            Only if size is not given.
             E.g., for sigma = 1 and truncate = 4.0, the kernel size is 9x9.
             '''
         )
@@ -68,7 +68,6 @@ class EISMexicanHatFilter(EISProcessingAlgorithm):
         size_param.setHelp(
             '''
             The size of the filter window. E.g., 3 means a 3x3 window.
-            Default to None.
             '''
         )
         self.addParameter(size_param)
@@ -82,7 +81,7 @@ class EISMexicanHatFilter(EISProcessingAlgorithm):
         direction_param.setHelp(
             '''
             The direction of calculating the kernel values.
-            Can be either 'rectangular' or 'circular'. Default to 'circular'.
+            Can be either 'rectangular' or 'circular'.
             '''
         )
         self.addParameter(direction_param)

--- a/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
@@ -37,7 +37,7 @@ class EISMexicanHatFilter(EISProcessingAlgorithm):
         sigma_param = QgsProcessingParameterNumber(
             name=self.alg_parameters[1],
             description="Sigma",
-            minValue=1.0,
+            minValue=0.001,
             defaultValue=1.0,
             type=QgsProcessingParameterNumber.Double,
         )

--- a/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
+++ b/eis_qgis_plugin/processing/algorithms/filtering/mexican_hat_filter.py
@@ -1,0 +1,94 @@
+from qgis.core import (
+    QgsProcessingParameterEnum,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterRasterLayer,
+)
+
+from eis_qgis_plugin.processing.eis_processing_algorithm import EISProcessingAlgorithm
+
+
+class EISMexicanHatFilter(EISProcessingAlgorithm):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._name = "mexican_hat_filter"
+        self._display_name = "Mexican Hat Filter"
+        self._group = "Filtering"
+        self._group_id = "filtering"
+        self._short_help_string = "Apply a Mexican hat filter to the input raster"
+
+    def initAlgorithm(self, config=None):
+        self.alg_parameters = [
+            "input_raster",
+            "sigma",
+            "truncate",
+            "size",
+            "direction",
+            "output_raster",
+        ]
+
+        input_raster_param = QgsProcessingParameterRasterLayer(
+                name=self.alg_parameters[0], description="Input raster"
+            )
+        input_raster_param.setHelp("The input raster data set.")
+        self.addParameter(input_raster_param)
+
+        sigma_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[1],
+            description="Sigma",
+            minValue=1.0,
+            defaultValue=1.0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        sigma_param.setHelp("The standard deviation.")
+        self.addParameter(sigma_param)
+
+        truncate_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[2],
+            description="Truncate",
+            minValue=1.0,
+            defaultValue=4.0,
+            type=QgsProcessingParameterNumber.Double,
+        )
+        truncate_param.setHelp(
+            '''
+            The truncation factor for the gaussian kernel based on the sigma value.
+            Only if size is not given. Default to 4.0.
+            E.g., for sigma = 1 and truncate = 4.0, the kernel size is 9x9.
+            '''
+        )
+        self.addParameter(truncate_param)
+
+        size_param = QgsProcessingParameterNumber(
+            name=self.alg_parameters[3],
+            description="Size",
+            optional=True,
+        )
+        size_param.setHelp(
+            '''
+            The size of the filter window. E.g., 3 means a 3x3 window.
+            Default to None.
+            '''
+        )
+        self.addParameter(size_param)
+           
+        direction_param = QgsProcessingParameterEnum(
+            name=self.alg_parameters[4],
+            description="Shape",
+            options=["circular", "rectangular"],
+            defaultValue="circular",
+        )
+        direction_param.setHelp(
+            '''
+            The direction of calculating the kernel values.
+            Can be either 'rectangular' or 'circular'. Default to 'circular'.
+            '''
+        )
+        self.addParameter(direction_param)
+
+        output_raster_param = QgsProcessingParameterRasterDestination(
+            name=self.alg_parameters[5], description="Output raster"
+        )
+        output_raster_param.setHelp("The output raster data set.")
+        self.addParameter(output_raster_param)

--- a/eis_qgis_plugin/processing/eis_provider.py
+++ b/eis_qgis_plugin/processing/eis_provider.py
@@ -34,11 +34,13 @@ class EISProvider(QgsProcessingProvider):
         prediction = self.load_algorithms_from_directory("prediction")
         transformations = self.load_algorithms_from_directory("transformations")
         utilities = self.load_algorithms_from_directory("utilities")
+        filtering = self.load_algorithms_from_directory("filtering")
 
         # Add the algorithm instances to the provider
         for algorithm in (
             validation + vector_processing + raster_processing +
-            exploratory_analysis + prediction + transformations + utilities
+            exploratory_analysis + prediction + transformations + utilities +
+            filtering
         ):
             self.addAlgorithm(algorithm)
 


### PR DESCRIPTION
This pull request adds the following filtering functions to the plugin in a new group called `Filtering`

- Focal filter
- Frost filter
- Gamma filter
- Gaussian filter
- Kuan filter
- Lee additive multiplicative noise filter
- Lee additive noise filter
- Lee enhanced filter
- Lee multiplicative noise filter
- Mexican hat filter

All of the above filtering functions were ran successfully in QGIS.

**Note** I put plausible values to `minValue` in the filter functions. If those need corrections, let me know.